### PR TITLE
Fixed IMigrator from being overwritten when multiple DBContexts are used

### DIFF
--- a/EntityFrameworkCore.TemporalTables/Extensions/IServiceCollectionExtensions.cs
+++ b/EntityFrameworkCore.TemporalTables/Extensions/IServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using EntityFrameworkCore.TemporalTables.Sql.Table;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace EntityFrameworkCore.TemporalTables.Extensions
 {
@@ -21,7 +22,9 @@ namespace EntityFrameworkCore.TemporalTables.Extensions
             services.AddScoped<ITableHelper<TContext>, TableHelper<TContext>>();
             services.AddScoped<ITemporalTableSqlBuilder<TContext>, TemporalTableSqlBuilder<TContext>>();
             services.AddScoped<ITemporalTableSqlExecutor<TContext>, TemporalTableSqlExecutor<TContext>>();
-            services.AddScoped<IMigrator, TemporalTableMigrator<TContext>>();
+            //services.AddScoped<IMigrator, TemporalTableMigrator<TContext>>(); //<-- with 2 temporal-DbContexts, an IMigrator gets registered twice, the second migrator takes precedence, so it is called by EF, even when the other Context is passed as the arg to the CLI tool
+            services.AddScoped<ITemporalTableMigrator, TemporalTableMigrator<TContext>>();
+            services.AddScoped<IMigrator, TemporalTableMigratorResolver>();
             services.AddScoped<IMigrationsSqlGenerator, TemporalTablesMigrationsSqlGenerator<TContext>>();
 
             services.AddSingleton<ITemporalTableSqlGeneratorFactory, TemporalTableSqlGeneratorFactory>();

--- a/EntityFrameworkCore.TemporalTables/Migrations/ITemporalTableMigrator.cs
+++ b/EntityFrameworkCore.TemporalTables/Migrations/ITemporalTableMigrator.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace EntityFrameworkCore.TemporalTables.Migrations
+{
+    public interface ITemporalTableMigrator : IMigrator
+    {
+    }
+}

--- a/EntityFrameworkCore.TemporalTables/Migrations/TemporalTableMigratorResolver.cs
+++ b/EntityFrameworkCore.TemporalTables/Migrations/TemporalTableMigratorResolver.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace EntityFrameworkCore.TemporalTables.Migrations
+{
+    internal class TemporalTableMigratorResolver : IMigrator
+    {
+        private IMigrator CurrentTemporalTableMigrator { get; set; }
+
+        private static Type ReflectiveTemporalTableManager(ICurrentDbContext currentDbContext) => typeof(TemporalTableMigrator<>).MakeGenericType(currentDbContext.Context.GetType());
+
+        public TemporalTableMigratorResolver(IEnumerable<ITemporalTableMigrator> temporalTableMigrators, ICurrentDbContext currentDbContext)
+        {
+            CurrentTemporalTableMigrator = temporalTableMigrators.LastOrDefault(m => ReflectiveTemporalTableManager(currentDbContext).IsAssignableFrom(m.GetType()));
+        }
+
+        public string GenerateScript(string fromMigration = null, string toMigration = null, bool idempotent = false)
+        {
+            return CurrentTemporalTableMigrator.GenerateScript(fromMigration, toMigration, idempotent);
+        }
+
+        public void Migrate(string targetMigration = null)
+        {
+            CurrentTemporalTableMigrator.Migrate(targetMigration);
+        }
+
+        public async Task MigrateAsync(string targetMigration = null, CancellationToken cancellationToken = default)
+        {
+            await CurrentTemporalTableMigrator.MigrateAsync(targetMigration, cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
fixes [18#issue-658358870](https://github.com/findulov/EntityFrameworkCore.TemporalTables/issues/18#issue-658358870)