### PR TITLE
Feature/add period columns to queries

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,110 @@
+# Rules in this file were initially inferred by Visual Studio IntelliCode from the C:\Users\B406\source\repos\Sandbox\EntityFrameworkCore.TemporalTables codebase based on best match to current usage at 02/01/2021
+# You can modify the rules from these initially generated values to suit your own policies
+# You can learn more about editorconfig here: https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference
+[*.cs]
+
+
+#Core editorconfig formatting - indentation
+
+#use soft tabs (spaces) for indentation
+indent_style = space
+indent_size = 4
+
+#Formatting - new line options
+
+#place else statements on a new line
+csharp_new_line_before_else = true
+#require members of anonymous types to be on separate lines
+csharp_new_line_before_members_in_anonymous_types = true
+#require members of object initializers to be on the same line
+csharp_new_line_before_members_in_object_initializers = false
+#require braces to be on a new line for methods, lambdas, types, and control_blocks (also known as "Allman" style)
+csharp_new_line_before_open_brace = methods, lambdas, types, control_blocks
+
+#Formatting - organize using options
+
+#do not place System.* using directives before other using directives
+dotnet_sort_system_directives_first = false
+
+#Formatting - spacing options
+
+#require a space before the colon for bases or interfaces in a type declaration
+csharp_space_after_colon_in_inheritance_clause = true
+#require a space after a keyword in a control flow statement such as a for loop
+csharp_space_after_keywords_in_control_flow_statements = true
+#require a space before the colon for bases or interfaces in a type declaration
+csharp_space_before_colon_in_inheritance_clause = true
+#remove space within empty argument list parentheses
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+#remove space between method call name and opening parenthesis
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+#do not place space characters after the opening parenthesis and before the closing parenthesis of a method call
+csharp_space_between_method_call_parameter_list_parentheses = false
+#remove space within empty parameter list parentheses for a method declaration
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+#place a space character after the opening parenthesis and before the closing parenthesis of a method declaration parameter list.
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+
+#Formatting - wrapping options
+
+#leave code block on single line
+csharp_preserve_single_line_blocks = true
+
+#Style - Code block preferences
+
+#prefer curly braces even for one line of code
+csharp_prefer_braces = true:suggestion
+
+#Style - expression bodied member options
+
+#prefer block bodies for constructors
+csharp_style_expression_bodied_constructors = false:suggestion
+#prefer block bodies for methods
+csharp_style_expression_bodied_methods = false:suggestion
+
+#Style - expression level options
+
+#prefer out variables to be declared inline in the argument list of a method call when possible
+csharp_style_inlined_variable_declaration = true:suggestion
+#prefer the language keyword for member access expressions, instead of the type name, for types that have a keyword to represent them
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+#Style - Expression-level  preferences
+
+#prefer default over default(T)
+csharp_prefer_simple_default_expression = true:suggestion
+#prefer inferred anonymous type member names
+dotnet_style_prefer_inferred_anonymous_type_member_names = false:suggestion
+
+#Style - implicit and explicit types
+
+#prefer var over explicit type in all cases, unless overridden by another code style rule
+csharp_style_var_elsewhere = true:suggestion
+#prefer explicit type over var to declare variables with built-in system types such as int
+csharp_style_var_for_built_in_types = false:suggestion
+#prefer explicit type over var when the type is already mentioned on the right-hand side of a declaration
+csharp_style_var_when_type_is_apparent = false:suggestion
+
+#Style - language keyword and framework type options
+
+#prefer the language keyword for local variables, method parameters, and class members, instead of the type name, for types that have a keyword to represent them
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+
+#Style - modifier options
+
+#prefer accessibility modifiers to be declared except for public interface members. This will currently not differ from always and will act as future proofing for if C# adds default interface methods.
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion
+
+#Style - Modifier preferences
+
+#when this rule is set to a list of modifiers, prefer the specified ordering.
+csharp_preferred_modifier_order = public,private,protected,internal,static,readonly,override,abstract,async:suggestion
+
+#Style - qualification options
+
+#prefer fields not to be prefaced with this. or Me. in Visual Basic
+dotnet_style_qualification_for_field = false:suggestion
+#prefer methods not to be prefaced with this. or Me. in Visual Basic
+dotnet_style_qualification_for_method = false:suggestion
+#prefer properties not to be prefaced with this. or Me. in Visual Basic
+dotnet_style_qualification_for_property = false:suggestion

--- a/EntityFrameworkCore.TemporalTables/Extensions/DbSetExtensions.cs
+++ b/EntityFrameworkCore.TemporalTables/Extensions/DbSetExtensions.cs
@@ -93,6 +93,50 @@ namespace EntityFrameworkCore.TemporalTables.Extensions
         }
 
         /// <summary>
+        /// Filters the DbSet with entities between the provided dates.
+        /// </summary>
+        /// <typeparam name="TEntity">The type of the entity.</typeparam>
+        /// <param name="dbSet">The database set.</param>
+        /// <param name="startDate">The start date.</param>
+        /// <param name="endDate">The end date.</param>
+        /// <returns>The entities found between the provided dates.</returns>
+        /// <remarks>The same entity might be returned more than once if it was modified
+        /// during that time frame.</remarks>
+        public static IQueryable<TEntity> ContainedIn<TEntity>(this DbSet<TEntity> dbSet, DateTime startDate, DateTime endDate)
+            where TEntity : class
+        {
+            ValidateDbSet(dbSet);
+            var PropertyNames = dbSet.GetMappedProperties();
+            PropertyNames = PropertyNames.IncludePeriodProperties();
+            var propertyNamesClause = string.Join(", ", PropertyNames);
+
+            var sql = FormattableString.Invariant($"SELECT {propertyNamesClause} FROM [{GetTableName(dbSet)}] FOR SYSTEM_TIME CONTAINED IN ({{0}}, {{1}})");
+            return dbSet.FromSqlRaw(sql, startDate, endDate).AsNoTracking();
+        }
+
+        /// <summary>
+        /// Filters the DbSet with entities between the provided dates.
+        /// </summary>
+        /// <typeparam name="TEntity">The type of the entity.</typeparam>
+        /// <param name="dbSet">The database set.</param>
+        /// <param name="startDateOffset">The start date time offset.</param>
+        /// <param name="endDateOffset">The end date time offset.</param>
+        /// <returns>The entities found between the provided dates.</returns>
+        /// <remarks>The same entity might be returned more than once if it was modified
+        /// during that time frame.</remarks>
+        public static IQueryable<TEntity> ContainedIn<TEntity>(this DbSet<TEntity> dbSet, DateTimeOffset startDateOffset, DateTimeOffset endDateOffset)
+            where TEntity : class
+        {
+            ValidateDbSet(dbSet);
+            var PropertyNames = dbSet.GetMappedProperties();
+            PropertyNames = PropertyNames.IncludePeriodProperties();
+            var propertyNamesClause = string.Join(", ", PropertyNames);
+
+            var sql = FormattableString.Invariant($"SELECT {propertyNamesClause} FROM [{GetTableName(dbSet)}] FOR SYSTEM_TIME CONTAINED IN ({{0}}, {{1}})");
+            return dbSet.FromSqlRaw(sql, startDateOffset, endDateOffset).AsNoTracking();
+        }
+
+        /// <summary>
         /// Selects the entities for all time periods
         /// </summary>
         /// <typeparam name="TEntity">The type of the entity.</typeparam>


### PR DESCRIPTION
This PR may be a little premature. I have a need to be able to see the period columns when querying the complete history of an entity. Since the period columns are hard-coded* in this project, it seems fitting that the temporal table queries include the columns.
*I think the period columns should be a little more flexible in the long run - which is something that I may consider working on myself, if/when I get time. This would also go hand-in-hand with issue [#27 - add functionality to specify temporal table name and schema](https://github.com/findulov/EntityFrameworkCore.TemporalTables/issues/27) and [#2 - Configure temporal column names](https://github.com/findulov/EntityFrameworkCore.TemporalTables/issues/2).

For now, I offer this PR, which is enough to satisfy my simple use cases.

Thanks,
Isaac 