### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/EntityFrameworkCore.TemporalTables.Tests/EntityFrameworkCore.TemporalTables.Tests.csproj
+++ b/EntityFrameworkCore.TemporalTables.Tests/EntityFrameworkCore.TemporalTables.Tests.csproj
@@ -7,15 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Hi@findulov, I found an issue in the EntityFrameworkCore.TemporalTables.Tests.csproj:

Packages Microsoft.EntityFrameworkCore v5.0.0, Microsoft.EntityFrameworkCore.Design v5.0.0, Microsoft.EntityFrameworkCore.InMemory v5.0.0, Microsoft.EntityFrameworkCore.Relational v5.0.0, Microsoft.NET.Test.Sdk v16.5.0  and MSTest.TestAdapter v2.1.0 transitively introduce 93 dependencies into EntityFrameworkCore.TemporalTables’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/EntityFrameworkCore-TemporalTables.html)), while Microsoft.EntityFrameworkCore v5.0.4, Microsoft.EntityFrameworkCore.Design v5.0.4, Microsoft.EntityFrameworkCore.InMemory v5.0.4, Microsoft.EntityFrameworkCore.Relational v5.0.4, Microsoft.NET.Test.Sdk v16.6.0  and MSTest.TestAdapter v2.2.1 can only introduce 62 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/EntityFrameworkCore-TemporalTables_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose